### PR TITLE
Support Go Modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 
 go:
-  - 1.4
+  - 1.12.x

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bsphere/le_go
+
+go 1.12


### PR DESCRIPTION
Please consider adding a `go.mod` file and a semver compatible tag (eg. `v0.0.1` or `v1.0.0`) so that other libraries pinning to this module can do so by version and not by commit SHA.

Thank you for your consideration.

**EDIT:** I've also taken the liberty of bumping Travis to a version of Go that's supported by the Go team. However, if you support unmaintained versions of Go as well feel free to yell at me and I can drop that part of the change. Adding the `go.mod` file won't affect anything that old.