### PR TITLE
- Add concurrentWrites param to limit the maximum number of goroutines active logging at a time - Add `errOutput` param to allow users to direct errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 
 go:
-  - 1.4
+  - 1.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
  - Add a `Flush` method to the logger so we can wait for all messages to be sent
  - Add a timestamp to logs that timeout and get written to stdout
  - Fix `tcp write i/o timeout` causing an infinite loop in `writeToLogEntries`
+ - Add concurrentWrites param to limit the maximum number of goroutines active logging at a time
+ - Add `errOutput` param to allow users to direct errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
  - Set conn.WriteTimeout to 10s and failover to log package if we fail to write it out.
  - Wait a maximum of 10s for any locks before bailing and printing to stdout
  - Add a `Flush` method to the logger so we can wait for all messages to be sent
+ - Add a timestamp to logs that timeout and get written to stdout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
  - Set conn.WriteTimeout to 10s and failover to log package if we fail to write it out.
  - Wait a maximum of 10s for any locks before bailing and printing to stdout
+ - Add a `Flush` method to the logger so we can wait for all messages to be sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Untagged
 
  - Set conn.WriteTimeout to 10s and failover to log package if we fail to write it out.
+ - Wait a maximum of 10s for any locks before bailing and printing to stdout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
  - Wait a maximum of 10s for any locks before bailing and printing to stdout
  - Add a `Flush` method to the logger so we can wait for all messages to be sent
  - Add a timestamp to logs that timeout and get written to stdout
+ - Fix `tcp write i/o timeout` causing an infinite loop in `writeToLogEntries`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## Untagged
+
+ - Set conn.WriteTimeout to 10s and failover to log package if we fail to write it out.

--- a/le.go
+++ b/le.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -108,19 +109,28 @@ func (logger *Logger) ensureOpenConnection() error {
 
 // Fatal is same as Print() but calls to os.Exit(1)
 func (logger *Logger) Fatal(v ...interface{}) {
-	logger.Output(3, fmt.Sprint(v...))
+	err := logger.Output(3, fmt.Sprint(v...))
+	if err != nil {
+		fmt.Sprintf("Error in logger.Fatal", err.Error())
+	}
 	os.Exit(1)
 }
 
 // Fatalf is same as Printf() but calls to os.Exit(1)
 func (logger *Logger) Fatalf(format string, v ...interface{}) {
-	logger.Output(3, fmt.Sprintf(format, v...))
+	err := logger.Output(3, fmt.Sprintf(format, v...))
+	if err != nil {
+		fmt.Sprintf("Error in logger.Fatalf", err.Error())
+	}
 	os.Exit(1)
 }
 
 // Fatalln is same as Println() but calls to os.Exit(1)
 func (logger *Logger) Fatalln(v ...interface{}) {
-	logger.Output(3, fmt.Sprintln(v...))
+	err := logger.Output(3, fmt.Sprintln(v...))
+	if err != nil {
+		fmt.Sprintf("Error in logger.Fatalln", err.Error())
+	}
 	os.Exit(1)
 }
 
@@ -140,6 +150,13 @@ func (logger *Logger) Flags() int {
 // paths it will be 3.
 // Output does the actual writing to the TCP connection
 func (l *Logger) Output(calldepth int, s string) error {
+	defer func() {
+		if re := recover(); re != nil {
+			fmt.Printf("Panicked in logger.output %v\n", re)
+			debug.PrintStack()
+			panic(re)
+		}
+	}()
 	now := time.Now() // get this early.
 	var file string
 	var line int
@@ -175,21 +192,30 @@ func (l *Logger) Output(calldepth int, s string) error {
 // Panic is same as Print() but calls to panic
 func (logger *Logger) Panic(v ...interface{}) {
 	s := fmt.Sprint(v...)
-	logger.Output(3, s)
+	err := logger.Output(3, s)
+	if err != nil {
+		fmt.Sprintf("Error in logger.Panic", err.Error())
+	}
 	panic(s)
 }
 
 // Panicf is same as Printf() but calls to panic
 func (logger *Logger) Panicf(format string, v ...interface{}) {
 	s := fmt.Sprintf(format, v...)
-	logger.Output(3, s)
+	err := logger.Output(3, s)
+	if err != nil {
+		fmt.Sprintf("Error in logger.Panicf", err.Error())
+	}
 	panic(s)
 }
 
 // Panicln is same as Println() but calls to panic
 func (logger *Logger) Panicln(v ...interface{}) {
 	s := fmt.Sprintln(v...)
-	logger.Output(3, s)
+	err := logger.Output(3, s)
+	if err != nil {
+		fmt.Sprintf("Error in logger.Panicln", err.Error())
+	}
 	panic(s)
 }
 
@@ -202,17 +228,26 @@ func (logger *Logger) Prefix() string {
 
 // Print logs a message
 func (logger *Logger) Print(v ...interface{}) {
-	logger.Output(3, fmt.Sprint(v...))
+	err := logger.Output(3, fmt.Sprint(v...))
+	if err != nil {
+		fmt.Sprintf("Error in logger.Print", err.Error())
+	}
 }
 
 // Printf logs a formatted message
 func (logger *Logger) Printf(format string, v ...interface{}) {
-	logger.Output(3, fmt.Sprintf(format, v...))
+	err := logger.Output(3, fmt.Sprintf(format, v...))
+	if err != nil {
+		fmt.Sprintf("Error in logger.Printf", err.Error())
+	}
 }
 
 // Println logs a message with a linebreak
 func (logger *Logger) Println(v ...interface{}) {
-	logger.Output(3, fmt.Sprintln(v...))
+	err := logger.Output(3, fmt.Sprintln(v...))
+	if err != nil {
+		fmt.Sprintf("Error in logger.Println", err.Error())
+	}
 }
 
 // SetFlags sets the logger flags

--- a/le.go
+++ b/le.go
@@ -362,7 +362,7 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 	case <-l.writeLock:
 	case <-time.After(l.writeTimeout):
 		//Bail out here
-		fmt.Printf("Timedout waiting for logging writelock: wanted to log: %s", s)
+		fmt.Printf("%s: Timedout waiting for logging writelock: wanted to log: %s", time.Now().UTC(), s)
 		l._testTimedoutWrite()
 		return
 	}

--- a/le.go
+++ b/le.go
@@ -36,6 +36,7 @@ type Logger struct {
 	writeTimeout       time.Duration
 	_testWaitForWrite  *sync.WaitGroup
 	_testTimedoutWrite func()
+	wg                 *sync.WaitGroup
 }
 
 const lineSep = "\n"
@@ -65,6 +66,7 @@ func newEmptyLogger(host, token string) Logger {
 		writeLock:          make(chan struct{}, 1),
 		mu:                 make(chan struct{}, 1),
 		_testTimedoutWrite: func() {}, //NOP for prod
+		wg:                 &sync.WaitGroup{},
 	}
 	unlock(l.writeLock)
 	unlock(l.mu)
@@ -202,10 +204,16 @@ func (l *Logger) Output(calldepth int, s string, doAsync func()) {
 	count := strings.Count(s, lineSep)
 	s = strings.Replace(s, lineSep, "\u2028", count-1)
 
+	l.wg.Add(1)
 	go func() {
+		defer l.wg.Done()
 		l.writeToLogEntries(s, file, now, line)
 		doAsync()
 	}()
+}
+
+func (l *Logger) Flush() {
+	l.wg.Wait()
 }
 
 // Panic is same as Print() but calls to panic

--- a/le.go
+++ b/le.go
@@ -394,6 +394,7 @@ func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
 		if err != nil {
 			log.Printf("Error in write call: %s", err.Error())
 			log.Printf("Wanted to log: %s", s)
+			return
 		}
 
 		if l._testWaitForWrite != nil {

--- a/le.go
+++ b/le.go
@@ -45,10 +45,9 @@ const maxLogLength int = 65000 //add 535 chars of headroom for the filename, tim
 // choosing manual configuration and token based TCP connection.
 func Connect(host, token string) (*Logger, error) {
 	logger := Logger{
-		host:              host,
-		token:             token,
-		lastRefreshAt:     time.Now(),
-		_testWaitForWrite: nil,
+		host:          host,
+		token:         token,
+		lastRefreshAt: time.Now(),
 	}
 
 	if err := logger.openConnection(); err != nil {

--- a/le.go
+++ b/le.go
@@ -27,6 +27,7 @@ type Logger struct {
 	conn          net.Conn
 	flag          int
 	mu            sync.Mutex
+	writeLock     sync.Mutex
 	prefix        string
 	host          string
 	token         string
@@ -117,32 +118,17 @@ func (logger *Logger) ensureOpenConnection() error {
 
 // Fatal is same as Print() but calls to os.Exit(1)
 func (logger *Logger) Fatal(v ...interface{}) {
-	err := logger.Output(3, fmt.Sprint(v...))
-	if err != nil {
-		fmt.Sprintf("Error in logger.Fatal: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
-	}
-	os.Exit(1)
+	logger.Output(3, fmt.Sprint(v...), handleFatalActions)
 }
 
 // Fatalf is same as Printf() but calls to os.Exit(1)
 func (logger *Logger) Fatalf(format string, v ...interface{}) {
-	err := logger.Output(3, fmt.Sprintf(format, v...))
-	if err != nil {
-		fmt.Sprintf("Error in logger.Fatalf: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", fmt.Sprintf(format, v...))
-	}
-	os.Exit(1)
+	logger.Output(3, fmt.Sprintf(format, v...), handleFatalActions)
 }
 
 // Fatalln is same as Println() but calls to os.Exit(1)
 func (logger *Logger) Fatalln(v ...interface{}) {
-	err := logger.Output(3, fmt.Sprintln(v...))
-	if err != nil {
-		fmt.Sprintf("Error in logger.Fatalln: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
-	}
-	os.Exit(1)
+	logger.Output(3, fmt.Sprintln(v...), handleFatalActions)
 }
 
 // Flags returns the logger flags
@@ -160,7 +146,7 @@ func (logger *Logger) Flags() int {
 // provided for generality, although at the moment on all pre-defined
 // paths it will be 3.
 // Output does the actual writing to the TCP connection
-func (l *Logger) Output(calldepth int, s string) error {
+func (l *Logger) Output(calldepth int, s string, doAsync func()) {
 	defer func() {
 		if re := recover(); re != nil {
 			fmt.Printf("Panicked in logger.output %v\n", re)
@@ -189,59 +175,28 @@ func (l *Logger) Output(calldepth int, s string) error {
 	count := strings.Count(s, lineSep)
 	s = strings.Replace(s, lineSep, "\u2028", count-1)
 
-	var i, n int
-	var err error
-	for i = 0; i < len(s); i = i + n {
-		end := i + maxLogLength - 2
-		if end > len(s) {
-			end = len(s)
-		}
-		l.buf = l.buf[:0]
-		l.buf = append(l.buf, (l.token + " ")...)
-		l.formatHeader(&l.buf, now, file, line)
-		l.buf = append(l.buf, s[i:end]...)
-		if len(s) == 0 || s[len(s)-1] != '\n' {
-			l.buf = append(l.buf, '\n')
-		}
-		n, err = l.Write(l.buf)
-		if err != nil {
-			return err
-		}
-	}
-	return err
+	go func() {
+		l.writeToLogEntries(s, file, now, line)
+		doAsync()
+	}()
 }
 
 // Panic is same as Print() but calls to panic
 func (logger *Logger) Panic(v ...interface{}) {
 	s := fmt.Sprint(v...)
-	err := logger.Output(3, s)
-	if err != nil {
-		fmt.Sprintf("Error in logger.Panic: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", s)
-	}
-	panic(s)
+	logger.Output(3, s, handlePanicActions(s))
 }
 
 // Panicf is same as Printf() but calls to panic
 func (logger *Logger) Panicf(format string, v ...interface{}) {
 	s := fmt.Sprintf(format, v...)
-	err := logger.Output(3, s)
-	if err != nil {
-		fmt.Sprintf("Error in logger.Panicf: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", s)
-	}
-	panic(s)
+	logger.Output(3, s, handlePanicActions(s))
 }
 
 // Panicln is same as Println() but calls to panic
 func (logger *Logger) Panicln(v ...interface{}) {
 	s := fmt.Sprintln(v...)
-	err := logger.Output(3, s)
-	if err != nil {
-		fmt.Sprintf("Error in logger.Panicln: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", s)
-	}
-	panic(s)
+	logger.Output(3, s, handlePanicActions(s))
 }
 
 // Prefix returns the logger prefix
@@ -253,29 +208,17 @@ func (logger *Logger) Prefix() string {
 
 // Print logs a message
 func (logger *Logger) Print(v ...interface{}) {
-	err := logger.Output(3, fmt.Sprint(v...))
-	if err != nil {
-		fmt.Sprintf("Error in logger.Print: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
-	}
+	logger.Output(3, fmt.Sprint(v...), handlePrintActions)
 }
 
 // Printf logs a formatted message
 func (logger *Logger) Printf(format string, v ...interface{}) {
-	err := logger.Output(3, fmt.Sprintf(format, v...))
-	if err != nil {
-		fmt.Sprintf("Error in logger.Printf: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", fmt.Sprintf(format, v...))
-	}
+	logger.Output(3, fmt.Sprintf(format, v...), handlePrintActions)
 }
 
 // Println logs a message with a linebreak
 func (logger *Logger) Println(v ...interface{}) {
-	err := logger.Output(3, fmt.Sprintln(v...))
-	if err != nil {
-		fmt.Sprintf("Error in logger.Println: %s", err.Error())
-		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
-	}
+	logger.Output(3, fmt.Sprintln(v...), handlePrintActions)
 }
 
 // SetFlags sets the logger flags
@@ -370,4 +313,45 @@ func itoa(buf *[]byte, i int, wid int) {
 	// i < 10
 	b[bp] = byte('0' + i)
 	*buf = append(*buf, b[bp:]...)
+}
+
+func (l *Logger) writeToLogEntries(s, file string, now time.Time, line int) {
+	l.writeLock.Lock()
+	defer l.writeLock.Unlock()
+
+	var i, n int
+	var err error
+
+	for i = 0; i < len(s); i = i + n {
+		end := i + maxLogLength - 2
+		if end > len(s) {
+			end = len(s)
+		}
+		l.buf = l.buf[:0]
+		l.buf = append(l.buf, (l.token + " ")...)
+		l.formatHeader(&l.buf, now, file, line)
+		l.buf = append(l.buf, s[i:end]...)
+		if len(s) == 0 || s[len(s)-1] != '\n' {
+			l.buf = append(l.buf, '\n')
+		}
+		n, err = l.Write(l.buf)
+		if err != nil {
+			log.Printf("Error in write call: %s", err.Error())
+			log.Printf("Wanted to log: %s", s)
+		}
+	}
+}
+
+func handleFatalActions() {
+	os.Exit(1)
+}
+
+func handlePanicActions(s string) func() {
+	return func() {
+		panic(s)
+	}
+}
+
+func handlePrintActions() {
+	return
 }

--- a/le.go
+++ b/le.go
@@ -119,6 +119,7 @@ func (logger *Logger) Fatal(v ...interface{}) {
 	err := logger.Output(3, fmt.Sprint(v...))
 	if err != nil {
 		fmt.Sprintf("Error in logger.Fatal", err.Error())
+		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
 	}
 	os.Exit(1)
 }
@@ -128,6 +129,7 @@ func (logger *Logger) Fatalf(format string, v ...interface{}) {
 	err := logger.Output(3, fmt.Sprintf(format, v...))
 	if err != nil {
 		fmt.Sprintf("Error in logger.Fatalf", err.Error())
+		fmt.Sprintf("Wanted to log: %s", fmt.Sprintf(format, v...))
 	}
 	os.Exit(1)
 }
@@ -137,6 +139,7 @@ func (logger *Logger) Fatalln(v ...interface{}) {
 	err := logger.Output(3, fmt.Sprintln(v...))
 	if err != nil {
 		fmt.Sprintf("Error in logger.Fatalln", err.Error())
+		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
 	}
 	os.Exit(1)
 }
@@ -202,6 +205,7 @@ func (logger *Logger) Panic(v ...interface{}) {
 	err := logger.Output(3, s)
 	if err != nil {
 		fmt.Sprintf("Error in logger.Panic", err.Error())
+		fmt.Sprintf("Wanted to log: %s", s)
 	}
 	panic(s)
 }
@@ -212,6 +216,7 @@ func (logger *Logger) Panicf(format string, v ...interface{}) {
 	err := logger.Output(3, s)
 	if err != nil {
 		fmt.Sprintf("Error in logger.Panicf", err.Error())
+		fmt.Sprintf("Wanted to log: %s", s)
 	}
 	panic(s)
 }
@@ -222,6 +227,7 @@ func (logger *Logger) Panicln(v ...interface{}) {
 	err := logger.Output(3, s)
 	if err != nil {
 		fmt.Sprintf("Error in logger.Panicln", err.Error())
+		fmt.Sprintf("Wanted to log: %s", s)
 	}
 	panic(s)
 }
@@ -238,6 +244,7 @@ func (logger *Logger) Print(v ...interface{}) {
 	err := logger.Output(3, fmt.Sprint(v...))
 	if err != nil {
 		fmt.Sprintf("Error in logger.Print", err.Error())
+		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
 	}
 }
 
@@ -246,6 +253,7 @@ func (logger *Logger) Printf(format string, v ...interface{}) {
 	err := logger.Output(3, fmt.Sprintf(format, v...))
 	if err != nil {
 		fmt.Sprintf("Error in logger.Printf", err.Error())
+		fmt.Sprintf("Wanted to log: %s", fmt.Sprintf(format, v...))
 	}
 }
 
@@ -254,6 +262,7 @@ func (logger *Logger) Println(v ...interface{}) {
 	err := logger.Output(3, fmt.Sprintln(v...))
 	if err != nil {
 		fmt.Sprintf("Error in logger.Println", err.Error())
+		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
 	}
 }
 

--- a/le.go
+++ b/le.go
@@ -213,6 +213,13 @@ func (l *Logger) Output(calldepth int, s string, doAsync func()) {
 }
 
 func (l *Logger) Flush() {
+	defer func() {
+		if re := recover(); re != nil {
+			//Protect against misused waitgroups
+			//Usually won't be an issue if the Flush is not waiting a long time
+			log.Println("Recovered while flushing logs")
+		}
+	}()
 	l.wg.Wait()
 }
 

--- a/le.go
+++ b/le.go
@@ -129,7 +129,7 @@ func (logger *Logger) Fatal(v ...interface{}) {
 func (logger *Logger) Fatalf(format string, v ...interface{}) {
 	err := logger.Output(3, fmt.Sprintf(format, v...))
 	if err != nil {
-		fmt.Sprintf("Error in logger.Fatalf: %s",, err.Error())
+		fmt.Sprintf("Error in logger.Fatalf: %s", err.Error())
 		fmt.Sprintf("Wanted to log: %s", fmt.Sprintf(format, v...))
 	}
 	os.Exit(1)
@@ -139,7 +139,7 @@ func (logger *Logger) Fatalf(format string, v ...interface{}) {
 func (logger *Logger) Fatalln(v ...interface{}) {
 	err := logger.Output(3, fmt.Sprintln(v...))
 	if err != nil {
-		fmt.Sprintf("Error in logger.Fatalln: %s",, err.Error())
+		fmt.Sprintf("Error in logger.Fatalln: %s", err.Error())
 		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
 	}
 	os.Exit(1)
@@ -216,7 +216,7 @@ func (logger *Logger) Panic(v ...interface{}) {
 	s := fmt.Sprint(v...)
 	err := logger.Output(3, s)
 	if err != nil {
-		fmt.Sprintf("Error in logger.Panic: %s",, err.Error())
+		fmt.Sprintf("Error in logger.Panic: %s", err.Error())
 		fmt.Sprintf("Wanted to log: %s", s)
 	}
 	panic(s)
@@ -227,7 +227,7 @@ func (logger *Logger) Panicf(format string, v ...interface{}) {
 	s := fmt.Sprintf(format, v...)
 	err := logger.Output(3, s)
 	if err != nil {
-		fmt.Sprintf("Error in logger.Panicf: %s",, err.Error())
+		fmt.Sprintf("Error in logger.Panicf: %s", err.Error())
 		fmt.Sprintf("Wanted to log: %s", s)
 	}
 	panic(s)
@@ -238,7 +238,7 @@ func (logger *Logger) Panicln(v ...interface{}) {
 	s := fmt.Sprintln(v...)
 	err := logger.Output(3, s)
 	if err != nil {
-		fmt.Sprintf("Error in logger.Panicln: %s",, err.Error())
+		fmt.Sprintf("Error in logger.Panicln: %s", err.Error())
 		fmt.Sprintf("Wanted to log: %s", s)
 	}
 	panic(s)
@@ -255,7 +255,7 @@ func (logger *Logger) Prefix() string {
 func (logger *Logger) Print(v ...interface{}) {
 	err := logger.Output(3, fmt.Sprint(v...))
 	if err != nil {
-		fmt.Sprintf("Error in logger.Print: %s",, err.Error())
+		fmt.Sprintf("Error in logger.Print: %s", err.Error())
 		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
 	}
 }
@@ -264,7 +264,7 @@ func (logger *Logger) Print(v ...interface{}) {
 func (logger *Logger) Printf(format string, v ...interface{}) {
 	err := logger.Output(3, fmt.Sprintf(format, v...))
 	if err != nil {
-		fmt.Sprintf("Error in logger.Printf: %s",, err.Error())
+		fmt.Sprintf("Error in logger.Printf: %s", err.Error())
 		fmt.Sprintf("Wanted to log: %s", fmt.Sprintf(format, v...))
 	}
 }
@@ -273,7 +273,7 @@ func (logger *Logger) Printf(format string, v ...interface{}) {
 func (logger *Logger) Println(v ...interface{}) {
 	err := logger.Output(3, fmt.Sprintln(v...))
 	if err != nil {
-		fmt.Sprintf("Error in logger.Println: %s",, err.Error())
+		fmt.Sprintf("Error in logger.Println: %s", err.Error())
 		fmt.Sprintf("Wanted to log: %s", fmt.Sprint(v...))
 	}
 }

--- a/le.go
+++ b/le.go
@@ -80,6 +80,7 @@ func (logger *Logger) isOpenConnection() bool {
 	}
 
 	if time.Now().After(logger.lastRefreshAt.Add(15 * time.Minute)) {
+		logger.conn.Close()
 		return false
 	}
 

--- a/le.go
+++ b/le.go
@@ -24,13 +24,14 @@ import (
 // log operations can be invoked in a non-blocking way by calling them from
 // a goroutine.
 type Logger struct {
-	conn   net.Conn
-	flag   int
-	mu     sync.Mutex
-	prefix string
-	host   string
-	token  string
-	buf    []byte
+	conn          net.Conn
+	flag          int
+	mu            sync.Mutex
+	prefix        string
+	host          string
+	token         string
+	buf           []byte
+	lastRefreshAt time.Time
 }
 
 const lineSep = "\n"
@@ -41,8 +42,9 @@ const lineSep = "\n"
 // choosing manual configuration and token based TCP connection.
 func Connect(host, token string) (*Logger, error) {
 	logger := Logger{
-		host:  host,
-		token: token,
+		host:          host,
+		token:         token,
+		lastRefreshAt: time.Now(),
 	}
 
 	if err := logger.openConnection(); err != nil {
@@ -74,6 +76,10 @@ func (logger *Logger) openConnection() error {
 // It returns if the TCP connection to logentries.com is open
 func (logger *Logger) isOpenConnection() bool {
 	if logger.conn == nil {
+		return false
+	}
+
+	if time.Now().After(logger.lastRefreshAt.Add(15 * time.Minute)) {
 		return false
 	}
 

--- a/le_test.go
+++ b/le_test.go
@@ -232,7 +232,7 @@ func TestTimeoutWrites(t *testing.T) {
 	}
 
 	le._testWaitForWrite = &sync.WaitGroup{}
-	le._testWaitForWrite.Add(1) // 3 because we need to write 3 times since it exceeds the limit (64k)
+	le._testWaitForWrite.Add(1)
 
 	defer le.Close()
 

--- a/le_test.go
+++ b/le_test.go
@@ -156,6 +156,7 @@ func TestReplaceNewline(t *testing.T) {
 
 	le.Println("1\n2\n3")
 
+	<-time.After(10 * time.Millisecond)
 	if strings.Count(string(le.buf), "\u2028") != 2 {
 		t.Fail()
 	}
@@ -171,11 +172,15 @@ func TestAddNewline(t *testing.T) {
 
 	le.Print("123")
 
+	<-time.After(10 * time.Millisecond)
+
 	if !strings.HasSuffix(string(le.buf), "\n") {
 		t.Fail()
 	}
 
 	le.Printf("%s", "123")
+
+	<-time.After(10 * time.Millisecond)
 
 	if !strings.HasSuffix(string(le.buf), "\n") {
 		t.Fail()
@@ -200,6 +205,7 @@ func TestCanSendMoreThan64k(t *testing.T) {
 	le.conn = &fakeConn
 	le.Print(longString)
 
+	<-time.After(10 * time.Millisecond)
 	if fakeConn.WriteCalls < 2 {
 		t.Fail()
 	}

--- a/le_test.go
+++ b/le_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -152,11 +153,15 @@ func TestReplaceNewline(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	le._testWaitForWrite = &sync.WaitGroup{}
+	le._testWaitForWrite.Add(1)
+
 	defer le.Close()
 
 	le.Println("1\n2\n3")
 
-	<-time.After(10 * time.Millisecond)
+	le._testWaitForWrite.Wait()
+
 	if strings.Count(string(le.buf), "\u2028") != 2 {
 		t.Fail()
 	}
@@ -168,19 +173,24 @@ func TestAddNewline(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	le._testWaitForWrite = &sync.WaitGroup{}
+	le._testWaitForWrite.Add(1)
+
 	defer le.Close()
 
 	le.Print("123")
 
-	<-time.After(10 * time.Millisecond)
+	le._testWaitForWrite.Wait()
 
 	if !strings.HasSuffix(string(le.buf), "\n") {
 		t.Fail()
 	}
 
+	le._testWaitForWrite.Add(1)
+
 	le.Printf("%s", "123")
 
-	<-time.After(10 * time.Millisecond)
+	le._testWaitForWrite.Wait()
 
 	if !strings.HasSuffix(string(le.buf), "\n") {
 		t.Fail()
@@ -192,6 +202,9 @@ func TestCanSendMoreThan64k(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	le._testWaitForWrite = &sync.WaitGroup{}
+	le._testWaitForWrite.Add(3) // 3 because we need to write 3 times since it exceeds the limit (64k)
 
 	defer le.Close()
 
@@ -205,7 +218,8 @@ func TestCanSendMoreThan64k(t *testing.T) {
 	le.conn = &fakeConn
 	le.Print(longString)
 
-	<-time.After(10 * time.Millisecond)
+	le._testWaitForWrite.Wait()
+
 	if fakeConn.WriteCalls < 2 {
 		t.Fail()
 	}

--- a/le_test.go
+++ b/le_test.go
@@ -225,13 +225,47 @@ func TestCanSendMoreThan64k(t *testing.T) {
 	}
 }
 
+func TestTimeoutWrites(t *testing.T) {
+	le, err := Connect("data.logentries.com:443", "myToken")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	le._testWaitForWrite = &sync.WaitGroup{}
+	le._testWaitForWrite.Add(1) // 3 because we need to write 3 times since it exceeds the limit (64k)
+
+	defer le.Close()
+
+	b := make([]byte, 1000)
+	for i := 0; i < 1000; i++ {
+		b[i] = 'a'
+	}
+	s := string(b)
+	// Fake the connection so we can hear about it
+	fakeConn := fakeConnection{}
+	le.conn = &fakeConn
+	le.Print(s)
+
+	le._testWaitForWrite.Wait()
+
+	if fakeConn.SetWriteTimeoutCalls < 1 {
+		t.Fail()
+	}
+}
+
 type fakeConnection struct {
-	WriteCalls int
+	WriteCalls           int
+	SetWriteTimeoutCalls int
 }
 
 func (f *fakeConnection) Write(b []byte) (int, error) {
 	f.WriteCalls++
 	return len(b), nil
+}
+
+func (f *fakeConnection) SetWriteDeadline(t time.Time) error {
+	f.SetWriteTimeoutCalls++
+	return nil
 }
 
 func (*fakeConnection) Read(b []byte) (int, error) {
@@ -240,11 +274,10 @@ func (*fakeConnection) Read(b []byte) (int, error) {
 
 func (*fakeConnection) SetReadDeadline(time.Time) error { return nil }
 
-func (*fakeConnection) Close() error                       { return nil }
-func (*fakeConnection) LocalAddr() net.Addr                { return &fakeAddr{} }
-func (*fakeConnection) RemoteAddr() net.Addr               { return &fakeAddr{} }
-func (*fakeConnection) SetDeadline(t time.Time) error      { return nil }
-func (*fakeConnection) SetWriteDeadline(t time.Time) error { return nil }
+func (*fakeConnection) Close() error                  { return nil }
+func (*fakeConnection) LocalAddr() net.Addr           { return &fakeAddr{} }
+func (*fakeConnection) RemoteAddr() net.Addr          { return &fakeAddr{} }
+func (*fakeConnection) SetDeadline(t time.Time) error { return nil }
 
 type fakeError struct{}
 


### PR DESCRIPTION
This is in preparation to allow synchroniser to properly log all logs to disk, and add an upperbound to the logging goroutines so we don't use up all CPU
